### PR TITLE
improve shell scripts

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-set -e
+
+set -eu
 
 git submodule init
 git submodule update
@@ -7,4 +8,3 @@ git submodule update
 make PLATFORM=bluepill
 make PLATFORM=stlinkv2
 make PLATFORM=stlinkv2dfu
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ addons:
       - binutils-arm-none-eabi
 
 language: c
-dist: trusty
 compiler: gcc
 
 notifications:

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
-#!/bin/bash
-set -e
-PROJECT="dirtyjtag"
+#!/bin/sh
+
+set -eu
+
+PROJECT=dirtyjtag
+
 docker build -t dirtyjtag -f Dockerfile .
-docker run -v $PWD:/mnt dirtyjtag bash -c "cp -v /home/$PROJECT/code/src/*.bin /mnt"
+docker run -v "${PWD}:/mnt" dirtyjtag bash -c "cp -v /home/${PROJECT}/code/src/*.bin /mnt"


### PR DESCRIPTION
Hiya,

I ran `shellcheck` on the shell scripts and fixed what I found. I also switched them to `/bin/sh` so they are more *portable* and added `set -u` so they are more *robust*.

While I was looking at the Travis file, I noticed a duplicated `dist: trusty`, I removed it.

Cheers.