### PR TITLE
Use systick instead of ASM code for delays

### DIFF
--- a/src/delay.c
+++ b/src/delay.c
@@ -1,6 +1,6 @@
 /*
   Copyright (c) 2017 Jean THOMAS.
-  
+
   Permission is hereby granted, free of charge, to any person obtaining
   a copy of this software and associated documentation files (the "Software"),
   to deal in the Software without restriction, including without limitation
@@ -9,7 +9,7 @@
   is furnished to do so, subject to the following conditions:
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
-  
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
   OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -20,9 +20,8 @@
 */
 
 #include <unicore-mx/cm3/systick.h>
+#include <unicore-mx/stm32/gpio.h>
 #include <stdint.h>
-
-#define F_CPU 72000000
 
 static bool wait_for_irq;
 
@@ -30,17 +29,19 @@ void delay_init(void) {
   systick_set_clocksource(STK_CSR_CLKSOURCE_AHB);
 }
 
-void delay_us(const uint32_t delay) {
+void _internal_delay_us(const uint32_t delay_val) {
   wait_for_irq = true;
 
-  systick_set_reload(F_CPU * delay / 1000000);
-  systick_clear();
+  systick_set_reload(delay_val);
+  STK_CVR = 0;
   systick_interrupt_enable();
+  systick_counter_enable();
 
-  while (wait_for_irq);
+  //while (wait_for_irq);
 }
 
 void sys_tick_handler(void) {
-  wait_for_irq = false;
-  systick_interrupt_disable();
+  //wait_for_irq = false;
+  //systick_interrupt_disable();
+  gpio_toggle(GPIOA, GPIO5);
 }

--- a/src/delay.h
+++ b/src/delay.h
@@ -20,14 +20,22 @@
 */
 
 /**
- * @brief Halts code executation
+ * @brief Initialises 
  *
  * Halts code execution for a specified amount of time
  * expressed in microseconds. The function was copied
  * from the superbitrf-firmware project.
  *
- * I haven't measured its accuracy yet.
+ */
+void delay_init(void);
+
+/**
+ * @brief Halts code executation
+ *
+ * Halts code execution for a specified amount of time
+ * expressed in microseconds. This function is blocking.
+ * Its accuracy is okay-ish.
  *
  * @param delay Delay in microseconds
  */
-void delay_us(uint32_t delay);
+void delay_us(const uint32_t delay);

--- a/src/delay.h
+++ b/src/delay.h
@@ -38,4 +38,6 @@ void delay_init(void);
  *
  * @param delay Delay in microseconds
  */
-void delay_us(const uint32_t delay);
+void _internal_delay_us(const uint32_t delay_val);
+
+#define delay_us(X) _internal_delay_us(F_CPU * X / 1000000)

--- a/src/dirtyjtag.c
+++ b/src/dirtyjtag.c
@@ -46,7 +46,7 @@ void clean_nvic(void) {
 
 int main(void) {
   /* Clock init */
-  rcc_clock_setup_in_hsi_out_48mhz();
+  rcc_clock_setup_in_hse_8mhz_out_72mhz();
 
   /* ST-Link v2 specific */
 #if PLATFORM == HW_stlinkv2dfu
@@ -64,6 +64,8 @@ int main(void) {
   /* Disable watchdog */
   IWDG_KR = 0;
 #endif
+
+  delay_init();
   
   /* Peripherals reset/init */
   rcc_periph_clock_enable(RCC_GPIOA);


### PR DESCRIPTION
Hasn't been tested yet on hardware.