### PR TITLE
move away from interrupts to speed up the code 

### DIFF
--- a/src/jtag.h
+++ b/src/jtag.h
@@ -87,7 +87,7 @@ void jtag_set_srst(uint8_t value);
  * @param in Input data
  * @param out Output data
  */
-void jtag_transfer(uint16_t length, const uint8_t *in,
+void jtag_transfer(uint8_t length, const uint8_t *in,
 		   uint8_t *out);
 
 /**


### PR DESCRIPTION
Hello! 
I believe moving away from interrupts and polling for the timer to overflow allows for faster clock rates. I measured the actual clock rate with the current FW. It does not go above 250Khz. The reason is that we need 2 interrupts per clock cycles and the overhead of taking an interrupt (pushing regs on the stack, restoring them at the exit) takes away from the useful code. Since the code polls a variable anyway, polling for the counter status register is not an architectural change. The transfer loop can now be made simpler because it isn't made up of 2 calls. Less state needs to be maintained. The resulting code can go up to around 1300Khz. I measure an actual programming of a FPGA with OpenFPGALoader to be close to 4x faster.  
I tried to minimize the code changes so the structure stays the same. 
Please let me know what you think. 
Happy new year, 
Patrick
