### PR TITLE
Use open-drain for SRST

### DIFF
--- a/src/jtag.c
+++ b/src/jtag.c
@@ -139,7 +139,7 @@ void jtag_init(void) {
 #if USE_SPI1
   /* SPI1 init */
   spi_reset(SPI1);
-  spi_init_master(SPI1, SPI_CR1_BAUDRATE_FPCLK_DIV_16, SPI_CR1_CPOL_CLK_TO_0_WHEN_IDLE, SPI_CR1_CPHA_CLK_TRANSITION_1,
+  spi_init_master(SPI1, SPI_CR1_BAUDRATE_FPCLK_DIV_8, SPI_CR1_CPOL_CLK_TO_0_WHEN_IDLE, SPI_CR1_CPHA_CLK_TRANSITION_1,
                   SPI_CR1_DFF_8BIT, SPI_CR1_MSBFIRST);
   spi_enable_software_slave_management(SPI1);
   spi_set_nss_high(SPI1);
@@ -371,6 +371,8 @@ void jtag_transfer(uint16_t length, const uint8_t *in, uint8_t *out) {
 
   if (max_frequency)
   {
+    /* Set TMS low during transfer */
+    jtag_set_tms(0);
     //set the pins in SPI mode
     gpio_set_mode(JTAG_PORT_TCK,
       GPIO_MODE_OUTPUT_50_MHZ,

--- a/src/jtag.c
+++ b/src/jtag.c
@@ -126,9 +126,9 @@ void jtag_init(void) {
 		JTAG_PIN_TMS);
 #ifdef JTAG_PORT_SRST
   gpio_set_mode(JTAG_PORT_SRST,
-		GPIO_MODE_OUTPUT_50_MHZ,
-		GPIO_CNF_OUTPUT_PUSHPULL,
-		JTAG_PIN_SRST);
+    GPIO_MODE_OUTPUT_50_MHZ,
+    GPIO_CNF_OUTPUT_OPENDRAIN,
+    JTAG_PIN_SRST);
 #endif
 #ifdef JTAG_PORT_TRST
   gpio_set_mode(JTAG_PORT_TRST,


### PR DESCRIPTION
I am proposing the following change:
Change RST from push-pull to open drain. This is safer in cases where the target board has another source of reset
Thanks! 
Patrick