### PR TITLE
Reduced available SRAM in linker script to be compatible to STM32F103C6

### DIFF
--- a/ld/stm32f1-noloader.ld
+++ b/ld/stm32f1-noloader.ld
@@ -1,7 +1,7 @@
 /* Generic STM32F1, no bootloader */
 MEMORY {
        rom (rx) : ORIGIN = 0x08000000, LENGTH = 128K
-       ram (rwx) : ORIGIN = 0x20000000, LENGTH = 20K
+       ram (rwx) : ORIGIN = 0x20000000, LENGTH = 10K
 }
 
 INCLUDE libucmx_stm32f1.ld


### PR DESCRIPTION
This addresses issue #91. Only the SRAM was reduced to the 10k of the C6 variant, FLASH was left as-is. This is usually not a problem, since the linker fills the FLASH image from the start, but if the SRAM is too short, the stack is not in the memory.

Tested on STM32F103C6, very confident that it will work on STM32F103C8.