### PR TITLE
Expand sloccount abbreviation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 DirtyJTAG is a JTAG adapter firmware for $2 ST-Link clones and generic STM32 development boards ("blue pill"/"black pill" STM32F101 and STM32F103 based ARM boards). The DirtyJTAG project was meant to be an alternative to the obsolete (but cheap) LPT Wiggler cables, and other expensive USB JTAG probes.
 
-DirtyJTAG is dirty and dirt cheap, but is not fast nor a perfect implementation of the JTAG protocol. Yet it is around 1k sloccount lines, making it easily understandable and hackable.
+DirtyJTAG is dirty and dirt cheap, but is not fast nor a perfect implementation of the JTAG protocol. Yet it is around 1k lines of code, making it easily understandable and hackable.
 
 If you prefer OpenOCD to UrJTAG, I suggest using Zoobab's fork of Versaloon firmware, which is available [on his GitHub repository](https://github.com/zoobab/versaloon).
 


### PR DESCRIPTION
It's even two characters less (although implying "source"). To me, this reads better than the original, while requiring no search engines.

(Feel free to ignore if you find this annoying rather than valuable. Either way, thanks for a great project!)